### PR TITLE
Suggestions for improvements

### DIFF
--- a/nature.bbx
+++ b/nature.bbx
@@ -18,6 +18,10 @@
 \DeclareBibliographyOption{articletitle}[true]{%
   \settoggle{bbx:articletitle}{#1}%
 }
+\newtoggle{bbx:intitle}
+\DeclareBibliographyOption{intitle}[false]{%
+  \settoggle{bbx:intitle}{#1}%
+}
 
 \@ifpackagelater{biblatex}{2016/03/27}
 {%
@@ -428,6 +432,12 @@
   \newunit\newblock
   \usebibmacro{byauthor}%
   \newunit\newblock
+  \iftoggle{bbx:intitle}
+    {%
+      \usebibmacro{title}%
+      \newblock
+    }
+    {}%
   \usebibmacro{in:}%
   \usebibmacro{bybookauthor}%
   \setunit*{\newunitpunct}\newblock
@@ -470,6 +480,12 @@
   \newunit\newblock
   \usebibmacro{byauthor}%
   \newunit\newblock
+  \iftoggle{bbx:intitle}
+    {%
+      \usebibmacro{title}%
+      \newblock
+    }
+    {}%
   \usebibmacro{in:}%
   \usebibmacro{maintitle+booktitle}%
   \newunit\newblock

--- a/nature.bbx
+++ b/nature.bbx
@@ -19,25 +19,34 @@
   \settoggle{bbx:articletitle}{#1}%
 }
 
-% Alter settings that carry through from biblatex
-\ExecuteBibliographyOptions{
-  articletitle        ,
-  giveninits          ,
-  maxnames     = 5    ,
-  maxcitenames = 2    ,
-  punctfont           ,
-  urldate      = year ,
-  useprefix           ,
+\@ifpackagelater{biblatex}{2016/03/27}
+{%
+  % Alter settings that carry through from biblatex
+  \ExecuteBibliographyOptions{
+    articletitle        ,
+    giveninits          ,
+    maxnames     = 5    ,
+    maxcitenames = 2    ,
+    punctfont           ,
+    urldate      = year ,
+    useprefix           ,
+  }
 }
+{%
+  % Alter settings that carry through from biblatex
+  \ExecuteBibliographyOptions{
+    articletitle        ,
+    firstinits          ,
+    maxnames     = 5    ,
+    maxcitenames = 2    ,
+    punctfont           ,
+    urldate      = year ,
+    useprefix           ,
+  }
+}%
 
 % Modify the name format
-\@ifpackageloaded{biblatex_legacy}
-  {
-    \DeclareNameFormat{default}{%
-      \usebibmacro{name:last-first}{#1}{#4}{#5}{#7}%
-     \usebibmacro{name:andothers}%
-    }
-  }
+\@ifpackagelater{biblatex}{2016/03/27}
   {
     \DeclareNameFormat{default}{%
       \nameparts{#1}%
@@ -47,6 +56,12 @@
         {\namepartprefix}
         {\namepartsuffix}%
      \usebibmacro{name:andothers}%
+    }
+  }
+  {
+    \DeclareNameFormat{default}{%
+      \usebibmacro{name:last-first}{#1}{#4}{#5}{#7}%
+      \usebibmacro{name:andothers}%
     }
   }
 


### PR DESCRIPTION
- Added 	4c644c7 for backwards compatibility for biblatex < 3.3 (2016/03/27), so biblatex-nature can be used in overleaf.com.
- Added 0a58f60 that adds support for the toggle `intitle` (`\usepackage[style=nature,intitle=true]{biblatex}`) that adds the title of the work to the reference for the ***@inbook*** and ***@incollection*** classes.