### PR TITLE
Add comma between event title and venue

### DIFF
--- a/biblatex-nature.bib
+++ b/biblatex-nature.bib
@@ -386,6 +386,14 @@
   edition     = {3},
 }
 
+@Unpublished{Doe2026,
+  author = {Doe, John},
+  title = {A title of a talk},
+  eventtitle = {{The Conference of Foobar}},
+  venue = {Neverland},
+  eventdate = {2026-01-01/2026-01-02}
+}
+
 %% 
 %% Copyright (C) 2010-2013,2016-2018,2020 by
 %%   Joseph Wright <joseph.wright at morningstar2.co.uk>

--- a/biblatex-nature.tex
+++ b/biblatex-nature.tex
@@ -95,6 +95,7 @@ be sent by e-mail to
 \changes{v1.3c}{2018/10/18}{Better \texttt{doi} support}
 \changes{v1.3c}{2018/10/18}{Better \texttt{related} support}
 \changes{v1.3d}{2020/12/30}{Adjust appearance of commentor string}
+\changes{v1.3e}{2026/04/21}{Fix punctuation between event name and venue in the \texttt{unpublished} type}
 
 \PrintChanges
 

--- a/nature.bbx
+++ b/nature.bbx
@@ -158,6 +158,7 @@
   }
     {}
     {%
+      \setunit*{\addcomma\space}%
       \printfield{venue}%
       \setunit*{\addcomma\space}%
       \printeventdate


### PR DESCRIPTION
Without this modification, an entry like this:
```
@unpublished{Rinne_etal2023,
  type = {poster},
  title = {A Comparison of Methods for Gap-Filling Sensible and Latent Heat Fluxes in Different Climatic Conditions},
  author = {Rinne, Erkka and Vekuri, Henriikka and Aurela, Mika and Tuovinen, Juha-Pekka},
  date = {2023-04-27},
  doi = {10.5194/egusphere-egu23-12035},
  eventtitle = {European {{Geosciences Union General Assembly}} 2023},
  venue = {Vienna, Austria}
}
```
would be typeset as:
> Rinne, E., Vekuri, H., Aurela, M. & Tuovinen, J.-P. A Comparison of Methods for Gap-Filling Sensible
> and Latent Heat Fluxes in Different Climatic Conditions poster. European Geosciences Union General
> Assembly 2023Vienna, Austria. 2023.

Note the last line.